### PR TITLE
Implement exception recording within `job.perform()` into spans

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -101,14 +101,6 @@ jobs:
         inputs: >-
           ./dist/*.tar.gz
           ./dist/*.whl
-    - name: Create GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        '${{ github.ref_name }}'
-        --repo '${{ github.repository }}'
-        --notes ""
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opentelemetry_instrumentation_rq"
-version = "0.0.3"
+version = "0.0.4"
 authors = [
   { name="K-T-Ng", email="l19so18h13k10@gmail.com" },
 ]


### PR DESCRIPTION
* feat: support recording exception raise by `job.peform()` to spans
* chore: bump package version to 0.0.4
* fix: remove create release job in workflow due to we will create manually