### PR TITLE
Support span link between job dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,12 @@
 # Opentelemetry Instrumentation for `rq`
 This library provides an OpenTelemetry Instrumentation library for Python RQ (Redis Queue). It enables distributed tracing and monitoring of tasks produced and processed by RQ workers, making it easier to gain insights into your application's performance and behavior.
 
-🚧 This project is currently under active development. Some features may not yet be supported. 🚧
-
-## Features
-### Currently Supported
+## Supported Features
 Automatic tracing when
 * Task producing, via `rq.queue.Queue._enqueue` or `rq.queue.Queue.schedule_job`
 * Task execution, via `rq.worker.Worker.perform_job`, `rq.job.Job.perform`
+* Span link between jobs which have dependencies (i.e, produce with `queue.enqueue(f, depends_on=xxx)`)
 * Callback function execution after a job succeeds, fails, or stops, via `rq.job.Job.execute_*_callback`
-
-### Planned
-- [ ] Enqueue Tracing
-    - [ ] Support span linking for job dependencies.
-    - [x] Add tracing for `rq.queue.Queue._enqueue` (not worked for schedlue job).
-    - [x] Add support for enqueue functions used by the RQ scheduler.
-- [x] Consumer Tracing
-    - [x] Add tracing for the outer layer `rq.worker.Worker.perform_job` to visualize the execution time for the entire fork process.
-    - [x] Add tracing for the inner layer `rq.job.Job.perform`.
-    - [x] Add tracing for the inner layer `handle_job_*`  to visualize post-processing after job execution.
-- [x] Improved Clarity
-    - [x] Refine span names and attributes for better readability and understanding.
-- [x] Adjust the dependencies version by testing the lower limit by github action.
 
 ## Installation
 Install this package with `pip`:
@@ -30,13 +15,16 @@ pip install opentemeletry_instrumentation_rq
 ```
 
 ## Usage
-### Automatic Instrumentation
+### Quick Start
 In your RQ producer or worker code, initialize the OpenTelemetry RQ instrumentation:
 ```python
 from opentelemetry_instrumentation_rq import RQInstrumentor
 
 RQInstrumentator().instrument()
 ```
+
+### Additional Scenarios
+For more use cases, refer to the tests in `tests/e2e_test`. You can launch an RQ worker using `tests/e2e_test/simulator/worker.py` and execute producer commands from `tests/e2e_test/test_simulation.py`.
 
 ## License
 This project is licensed under the [MIT License](./LICENSE).

--- a/opentelemetry_instrumentation_rq/__init__.py
+++ b/opentelemetry_instrumentation_rq/__init__.py
@@ -57,6 +57,22 @@ class RQInstrumentor(BaseInstrumentor):
             ),
         )
 
+        wrap_function_wrapper(
+            "rq.queue",
+            "Queue.setup_dependencies",
+            TraceInstrumentWrapper(
+                span_kind=trace.SpanKind.PRODUCER,
+                operation_type=MessagingOperationTypeValues.CREATE.value,
+                operation_name="setup dependencies",
+                should_propagate=True,
+                should_flush=False,
+                instance_info=utils.get_instance_info(utils.RQElementName.QUEUE),
+                argument_info_list=[
+                    utils.get_argument_info(utils.RQElementName.JOB, 0)
+                ],
+            ),
+        )
+
         # Instrumentation for task consumer
         wrap_function_wrapper(
             "rq.worker",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opentelemetry_instrumentation_rq"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name="K-T-Ng", email="l19so18h13k10@gmail.com" },
 ]

--- a/tests/e2e_test/model.py
+++ b/tests/e2e_test/model.py
@@ -29,6 +29,12 @@ class V1KeyValue(BaseModel):
     value: Any
 
 
+class V1SpanLink(BaseModel):
+    trace_id: str = Field(alias="traceId", default="")
+    span_id: str = Field(alias="span_id", default="")
+    attributes: List[V1KeyValue] = []
+
+
 class V1Span(BaseModel):
     trace_id: str = Field(alias="traceId")
     span_id: str = Field(alias="spanId")
@@ -38,6 +44,7 @@ class V1Span(BaseModel):
     start_time_unix_nano: int = Field(alias="startTimeUnixNano")
     end_time_unix_nano: int = Field(alias="endTimeUnixNano")
     attributes: List[V1KeyValue] = []
+    links: List[V1SpanLink] = []
     status: V1Status
 
     class Config:


### PR DESCRIPTION
### What's New
* Support span link between jobs with dependencies relation (i.e, job enqueue by `queue.enqueue(f, depends_on=xxx)`)

### Fix
* Fix nested tracing instrumentation not working when `RQInstrumentor` is involved. The reason is we are passing context to span context manager no matter what we extract from `job.meta` (possiblity empty dictionary).

### Others
* Update `README.md`