### PR TITLE
Loosening dependency version

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -21,7 +21,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        rq-version: ["1.15", "1.16", "2.0", "2.1.0"]
+        rq-version: ["1.15", "1.16", "2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6"]
+        exclude:
+          - python-version: "3.8"
+            rq-version: "2.4"
+          - python-version: "3.8"
+            rq-version: "2.5"
+          - python-version: "3.8"
+            rq-version: "2.6"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/requirements/pkg-requirements.txt
+++ b/requirements/pkg-requirements.txt
@@ -1,4 +1,4 @@
 rq>=1.15
 opentelemetry-api~=1.28
 opentelemetry-sdk~=1.28
-opentelemetry-instrumentation==0.50b0
+opentelemetry-instrumentation~=0.50b0

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -1,7 +1,7 @@
 fakeredis==2.26.1
 mock==5.1.0
 opentelemetry-exporter-otlp~=1.28
-opentelemetry-test-utils==0.50b0
+opentelemetry-test-utils~=0.50b0
 pydantic~=2.10
 pytest==8.3.3
 pytest-cov==5.0.0


### PR DESCRIPTION
* fix: loosening `opentelemetry-instrumentation` to compatible version rather than fixed version (0.50b0), related to #13 
* test: adding newer RQ version to automated testing