### PR TITLE
build: add py.typed to support type hint

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -37,9 +37,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install package
         run: |
+          pip install -Iv rq==${{ matrix.rq-version }}
           pip install -r requirements/pkg-requirements.txt
           pip install -r requirements/test-requirements.txt
-          pip install -Iv rq==${{ matrix.rq-version }}
       - name: Launch Redis, OpenTelemetry Collector and Jaeger
         run: |
           docker compose -f tests/e2e_test/env_setup/docker-compose.yaml up -d --wait

--- a/opentelemetry_instrumentation_rq/__init__.py
+++ b/opentelemetry_instrumentation_rq/__init__.py
@@ -21,7 +21,7 @@ class RQInstrumentor(BaseInstrumentor):
     """An instrumentor of rq"""
 
     def instrumentation_dependencies(self) -> Collection[str]:
-        return ("rq >= 2.0.0",)
+        return ("rq >= 1.15",)
 
     def _instrument(self, **kwargs):
         # Instrumentation for task producer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,9 @@ Homepage = "https://github.com/K-T-Ng/opentelemetry-instrumentation-rq"
 Issues = "https://github.com/K-T-Ng/opentelemetry-instrumentation-rq/issues"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/opentelemetry_instrumentation_rq"]
+packages = ["opentelemetry_instrumentation_rq"]
 
 [tool.hatch.build]
 include = [
-    "src/opentelemetry_instrumentation_rq/py.typed"
+    "opentelemetry_instrumentation_rq"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opentelemetry_instrumentation_rq"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
   { name="K-T-Ng", email="l19so18h13k10@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,11 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/K-T-Ng/opentelemetry-instrumentation-rq"
 Issues = "https://github.com/K-T-Ng/opentelemetry-instrumentation-rq/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry_instrumentation_rq"]
+
+[tool.hatch.build]
+include = [
+    "src/opentelemetry_instrumentation_rq/py.typed"
+]


### PR DESCRIPTION
This PR adding `py.typed` for supporting type hint, solving warning message reported by type checkers like mypy.

Related to #19 